### PR TITLE
chore(deps): adds ^17.x || ^18.x react versions as possible peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "sinon": "^4.4.2"
   },
   "peerDependencies": {
-    "react": "^15.5.x || ^16.x",
-    "react-dom": "^15.5.x || ^16.x"
+    "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+    "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
   },
   "files": [
     "lib"


### PR DESCRIPTION
In response for the issue #1, a PR adding ^17.x || ^18.x React and ReactDOM versions as possible peers.